### PR TITLE
Fix bug - Include check for iOS 10+ specific code

### DIFF
--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -199,7 +199,10 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
     }
     
     //wait until 10 seconds are buffered then play
-    player.currentItem.preferredForwardBufferDuration = 500;
+    float version = [[[UIDevice currentDevice] systemVersion] floatValue];
+    if (version >= 10.0) {
+        player.currentItem.preferredForwardBufferDuration = 500;
+    }
     Float64 durationSeconds = 0;
     while (durationSeconds < 10){
         NSValue *val = player.currentItem.loadedTimeRanges.firstObject;
@@ -211,7 +214,9 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
     
     // Callback when ready / failed
     if (player.currentItem.status == AVPlayerStatusReadyToPlay) {
-        player.automaticallyWaitsToMinimizeStalling = false;
+        if (version >= 10.0) {
+            player.automaticallyWaitsToMinimizeStalling = false;
+        }
         callback(@[[NSNull null]]);
     } else {
         NSDictionary* dict = [Helpers errObjWithCode:@"preparefail"


### PR DESCRIPTION
Without adding a check for the iOS version, the audio player was crashing on devices with iOS versions older than 10.