### PR TITLE
Use loadedTimeRanges instead of status to determine if player is ready

### DIFF
--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -162,6 +162,12 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber *)playerId
     ReactPlayer *player = [[ReactPlayer alloc]
                         initWithPlayerItem:item];
 
+    // If we don't set this property the player appears to play
+    //(so we update currentTime etc) but the system has actually paused playback to buffer
+    if ([player respondsToSelector:@selector(setAutomaticallyWaitsToMinimizeStalling:)]) {
+        player.automaticallyWaitsToMinimizeStalling = NO;
+    }
+
     // If successful, check options and add to player pool
     if (player) {
         NSNumber *autoDestroy = options[@"autoDestroy"];


### PR DESCRIPTION
- `AVPlayer`'s `status` can be unreliable, as reported here https://github.com/futurice/react-native-audio-toolkit/issues/41 and here https://stackoverflow.com/questions/5401437/knowing-when-avplayer-object-is-ready-to-play
- this was originally fixed by e60a26f87744224a95b0abdf873c95a05acb19a0 which used `currentItem.loadedTimeRanges` to determine readiness, but that created a race condition because it used `NSThread.sleepForTimeInterval` which could put `AudioPlayer` into a spin lock
- instead we use Key Value Observing, which doesn't create a race condition
- also this PR reintroduces disabling of `automaticallyWaitsToMinimizeStalling`, which stops our audio and currentTime getting out of sync

Fixes https://app.clubhouse.io/boilerroom/story/2222/the-audio-player-can-get-into-a-broken-state-when-going-offline-before-a-audio-stream-has-loaded-ios-only